### PR TITLE
Change base docker image used for testing from java11 to java17-debian11

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get Docker Images
         shell: bash
         run: |
-          docker pull gcr.io/distroless/java:11
+          docker pull gcr.io/distroless/java17-debian11
           uname -a
 
       - name: Set up JDK

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ COHERENCE_WKA2 ?= server1
 CLUSTER_PORT ?= 7574
 # Profiles to include for building
 PROFILES ?=
-COHERENCE_BASE_IMAGE ?= gcr.io/distroless/java:11
+COHERENCE_BASE_IMAGE ?= gcr.io/distroless/java17-debian11
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Set the location of various build tools

--- a/tests/java/pom.xml
+++ b/tests/java/pom.xml
@@ -40,7 +40,7 @@
     <coherence.test.groupId>com.oracle.coherence.ce</coherence.test.groupId>
     <coherence.test.version>${coherence.version}</coherence.test.version>
 
-    <coherence.test.base.image>gcr.io/distroless/java:11</coherence.test.base.image>
+    <coherence.test.base.image>gcr.io/distroless/java17-debian11</coherence.test.base.image>
 
     <!-- library dependency versions -->
     <version.lib.asciidoctor.diagram>2.2.1</version.lib.asciidoctor.diagram>


### PR DESCRIPTION
Change base docker image used for testing from java11 to java17-debian11 - this image includes support for arm64.  This avoids a docker warning about platform mismatches when testing on arm.