### PR TITLE
Wait for ready

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "maven"
-    directory: "/"
+    directory: "/tests/java/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pip"

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ test:  ##
 		tests/test_serialization.py \
 		tests/test_session.py \
 		tests/test_client.py \
+		tests/test_events.py \
 		tests/test_filters.py \
 		tests/test_processors.py \
 		tests/test_aggregators.py \

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,13 @@ generate-proto:  ## Generate Proto Files
 # ----------------------------------------------------------------------------------------------------------------------
 .PHONY: test
 test:  ##
-	pytest -W error --cov src/coherence --cov-report=term --cov-report=html
+	pytest -W error --cov src/coherence --capture=tee-sys --cov-report=term --cov-report=html \
+		tests/test_serialization.py \
+		tests/test_session.py \
+		tests/test_client.py \
+		tests/test_filters.py \
+		tests/test_processors.py \
+		tests/test_aggregators.py \
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Run standards validation across project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ jsonpickle = "~3.0"
 pymitter = "~0.4"
 
 [tool.poetry.dev-dependencies]
-pytest = "~7.3"
+pytest = "~7.4"
 pytest-asyncio = "~0.21"
 pytest-cov = "~4.1"
 pytest-unordered = "~0.5"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.

--- a/src/coherence/client.py
+++ b/src/coherence/client.py
@@ -1118,6 +1118,7 @@ class Options:
             except ValueError:
                 COH_LOG.warning(
                     "The timeout value of [%s] specified by environment variable [%s] cannot be converted to a float",
+                    timeout,
                     variable_name,
                 )
 

--- a/src/coherence/client.py
+++ b/src/coherence/client.py
@@ -8,6 +8,8 @@ import abc
 import asyncio
 import logging
 import os
+import time
+import uuid
 from asyncio import Condition, Task
 from threading import Lock
 from typing import (
@@ -62,7 +64,7 @@ def _pre_call_cache(func):
             raise Exception("Cache [{}] has been {}.".format(self.name, "released" if self.released else "destroyed"))
 
         # noinspection PyProtectedMember
-        await self._session._wait_for_active()
+        await self._session._wait_for_ready()
 
         return await func(self, *args, **kwargs)
 
@@ -577,6 +579,7 @@ class NamedCacheClient(NamedCache[K, V]):
         await self._client_stub.clear(r)
 
     async def destroy(self) -> None:
+        self.release()
         self._internal_emitter.once(MapLifecycleEvent.DESTROYED.value)
         self._internal_emitter.emit(MapLifecycleEvent.DESTROYED.value, self.name)
         r = self._request_factory.destroy_request()
@@ -771,6 +774,12 @@ class NamedCacheClient(NamedCache[K, V]):
         internal_emitter.on(MapLifecycleEvent.RELEASED.value, on_released)
         internal_emitter.on(MapLifecycleEvent.TRUNCATED.value, on_truncated)
 
+    def __str__(self) -> str:
+        return (
+            f"NamedCache(name={self.name}, session={self._session.session_id}, serializer={self._serializer},"
+            f" released={self.released}, destroyed={self.destroyed})"
+        )
+
 
 class TlsOptions:
     """
@@ -884,6 +893,12 @@ class TlsOptions:
     def is_locked(self) -> bool:
         return self._locked
 
+    def __str__(self) -> str:
+        return (
+            f"TlsOptions(enabled={self.enabled}, ca-cert-path={self.ca_cert_path}, "
+            f"client-cert-path={self.client_cert_path}, client-key-path={self.client_key_path})"
+        )
+
 
 class Options:
     """
@@ -902,6 +917,17 @@ class Options:
     request timeout is not passed as an argument in the constructor. If the environment variable is not set and
     request timeout is not passed as an argument then `DEFAULT_REQUEST_TIMEOUT` of 30 seconds is used
     """
+    ENV_READY_TIMEOUT = "COHERENCE_READY_TIMEOUT"
+    """
+    Environment variable to specify the maximum amount of time an NamedMap or NamedCache operations may wait for the
+    underlying gRPC channel to be ready.  This is independent of the request timeout which sets a deadline on how
+    long the call may take after being dispatched.
+    """
+    ENV_SESSION_DISCONNECT_TIMEOUT = "COHERENCE_SESSION_DISCONNECT_TIMEOUT"
+    """
+    Environment variable to specify the maximum amount of time, in seconds, a Session may remain in a disconnected
+    state without successfully reconnecting.
+    """
 
     DEFAULT_ADDRESS: Final[str] = "localhost:1408"
     """The default target address to connect to Coherence gRPC server."""
@@ -909,6 +935,16 @@ class Options:
     """The default scope."""
     DEFAULT_REQUEST_TIMEOUT: Final[float] = 30.0
     """The default request timeout."""
+    DEFAULT_READY_TIMEOUT: Final[float] = -1.0
+    """
+    The default ready timeout is -1.0 which disables the feature by default.  Explicit configure the ready timeout
+    session option or use the environment variable to specify a positive value indicating how many seconds an RPC will
+    wait for the underlying channel to be ready before failing.
+    """
+    DEFAULT_SESSION_DISCONNECT_TIMEOUT: Final[float] = 30.0
+    """
+    The default maximum time a session may be in a disconnected state without having successfully reconnected.
+    """
     DEFAULT_FORMAT: Final[str] = "json"
     """The default serialization format"""
 
@@ -917,6 +953,8 @@ class Options:
         address: str = DEFAULT_ADDRESS,
         scope: str = DEFAULT_SCOPE,
         request_timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT,
+        ready_timeout_seconds: float = DEFAULT_READY_TIMEOUT,
+        session_disconnect_seconds: float = DEFAULT_SESSION_DISCONNECT_TIMEOUT,
         ser_format: str = DEFAULT_FORMAT,
         channel_options: Optional[Sequence[Tuple[str, Any]]] = None,
         tls_options: Optional[TlsOptions] = None,
@@ -932,6 +970,13 @@ class Options:
         :param request_timeout_seconds: Defines the request timeout, in `seconds`, that will be applied to each
           remote call. If not explicitly set, this defaults to :func:`coherence.client.Options.DEFAULT_REQUEST_TIMEOUT`.
           See also :func:`coherence.client.Options.ENV_REQUEST_TIMEOUT`
+        :param ready_timeout_seconds: Defines the ready timeout, in `seconds`.  If this is a positive
+          float value, remote calls will not fail immediately if no connection is available.  If this is a value of zero
+          or less, then remote calls will fail-fast.  If not explicitly configured, the default of -1 is assumed.
+
+          See also :class:`coherence.client.Options.ENV_READY_TIMEOUT`
+        :param session_disconnect_seconds: Defines the maximum time, in `seconds`, that a session may remain in
+          a disconnected state without successfully reconnecting.
         :param ser_format: The serialization format.  Currently, this is always `json`
         :param channel_options: The `gRPC` `ChannelOptions`. See
             https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments and
@@ -944,17 +989,13 @@ class Options:
         else:
             self._address = address
 
-        timeout = os.getenv(Options.ENV_REQUEST_TIMEOUT)
-        if timeout is not None:
-            time_out: float
-            try:
-                time_out = float(timeout)
-            except ValueError:
-                COH_LOG.warning("The timeout value of [%s] cannot be converted to a float", Options.ENV_REQUEST_TIMEOUT)
-
-            self._request_timeout_seconds = time_out
-        else:
-            self._request_timeout_seconds = request_timeout_seconds
+        self._request_timeout_seconds = Options._get_float_from_env(
+            Options.ENV_REQUEST_TIMEOUT, request_timeout_seconds
+        )
+        self._ready_timeout_seconds = Options._get_float_from_env(Options.ENV_READY_TIMEOUT, ready_timeout_seconds)
+        self._session_disconnect_timeout_seconds = Options._get_float_from_env(
+            Options.ENV_READY_TIMEOUT, session_disconnect_seconds
+        )
 
         self._scope = scope
         self._ser_format = ser_format
@@ -1023,6 +1064,24 @@ class Options:
         return self._request_timeout_seconds
 
     @property
+    def ready_timeout_seconds(self) -> float:
+        """
+        Returns the ready timeout in `seconds`.
+
+        :return: the ready timeout in `seconds`
+        """
+        return self._ready_timeout_seconds
+
+    @property
+    def session_disconnect_timeout_seconds(self) -> float:
+        """
+        Returns the ready timeout in `seconds`.
+
+        :return: the ready timeout in `seconds`
+        """
+        return self._session_disconnect_timeout_seconds
+
+    @property
     def channel_options(self) -> Optional[Sequence[Tuple[str, Any]]]:
         """
         Return the `gRPC` `ChannelOptions`.
@@ -1039,6 +1098,42 @@ class Options:
         :param channel_options: the `gRPC` `ChannelOptions`.
         """
         self._channel_options = channel_options
+
+    @staticmethod
+    def _get_float_from_env(variable_name: str, default_value: float) -> float:
+        """
+        Return a float value parsed from the provided environment variable name.
+
+        :param variable_name: the environment variable name
+        :param default_value: the value to use if the environment variable is not set
+
+        :return: the float value from the environment or the default if the value can't be parsed
+          or the environment variable is not set
+        """
+        timeout = os.getenv(variable_name)
+        if timeout is not None:
+            time_out: float = default_value
+            try:
+                time_out = float(timeout)
+            except ValueError:
+                COH_LOG.warning(
+                    "The timeout value of [%s] specified by environment variable [%s] cannot be converted to a float",
+                    variable_name,
+                )
+
+            return time_out
+        else:
+            return default_value
+
+    def __str__(self) -> str:
+        return (
+            f"Options(address={self.address}, scope={self.scope}, format={self.format},"
+            f" request-timeout-seconds={self.request_timeout_seconds}, "
+            f"ready-timeout-seconds={self.ready_timeout_seconds}, "
+            f"session-disconnect-timeout-seconds={self.session_disconnect_timeout_seconds}, "
+            f"tls-options={self.tls_options}, "
+            f"channel-options={self.channel_options})"
+        )
 
 
 def _get_channel_creds(tls_options: TlsOptions) -> grpc.ChannelCredentials:
@@ -1090,14 +1185,29 @@ class Session:
         :param session_options: the provided :func:`coherence.client.Options`
         """
         self._closed: bool = False
-        self._active = False
-        self._active_condition: Condition = Condition()
+        self._session_id: str = str(uuid.uuid4())
+        self._ready = False
+        self._ready_condition: Condition = Condition()
         self._caches: dict[str, NamedCache[Any, Any]] = dict()
         self._lock: Lock = Lock()
         if session_options is not None:
             self._session_options = session_options
         else:
             self._session_options = Options()
+
+        self._ready_timeout_seconds: float = self._session_options.ready_timeout_seconds
+        self._ready_enabled: bool = self._ready_timeout_seconds > 0
+
+        interceptors = [
+            _InterceptorUnaryUnary(self),
+            _InterceptorUnaryStream(self),
+            _InterceptorStreamUnary(self),
+        ]
+
+        # only add the StreamStream interceptor if ready support is enabled as
+        # when added in the non-ready case, the call will not fail-fast
+        if self._ready_enabled:
+            interceptors.append(_InterceptorStreamStream(self))
 
         self._tasks: Set[Task[None]] = set()
 
@@ -1107,12 +1217,7 @@ class Session:
                 options=None
                 if self._session_options.channel_options is None
                 else self._session_options.channel_options,
-                interceptors=[
-                    _InterceptorUnaryUnary(self),
-                    _InterceptorUnaryStream(self),
-                    _InterceptorStreamUnary(self),
-                    _InterceptorStreamStream(self),
-                ],
+                interceptors=interceptors,
             )
         else:
             creds: grpc.ChannelCredentials = _get_channel_creds(self._session_options.tls_options)
@@ -1122,12 +1227,7 @@ class Session:
                 options=None
                 if self._session_options.channel_options is None
                 else self._session_options.channel_options,
-                interceptors=[
-                    _InterceptorUnaryUnary(self),
-                    _InterceptorUnaryStream(self),
-                    _InterceptorStreamUnary(self),
-                    _InterceptorStreamStream(self),
-                ],
+                interceptors=interceptors,
             )
 
         watch_task: Task[None] = asyncio.create_task(watch_channel_state(self))
@@ -1138,7 +1238,7 @@ class Session:
     @staticmethod
     async def create(session_options: Optional[Options] = None) -> Session:
         session: Session = Session(session_options)
-        await session._set_active(False)
+        await session._set_ready(False)
         return session
 
     # noinspection PyTypeHints
@@ -1205,11 +1305,26 @@ class Session:
     @property
     def closed(self) -> bool:
         """
-        Returns `True` if Session is closed else `False`
+        Returns `True` if Session is closed else `False`.
 
         :return: `True` if Session is closed else `False`
         """
         return self._closed
+
+    @property
+    def session_id(self) -> str:
+        """
+        Returns this Session's ID.
+
+        :return: this Session's ID
+        """
+        return self._session_id
+
+    def __str__(self) -> str:
+        return (
+            f"Session(id={self.session_id}, closed={self.closed}, state={self._channel.get_state(False)},"
+            f" caches/maps={len(self._caches)}, options={self.options})"
+        )
 
     # noinspection PyProtectedMember
     @_pre_call_session
@@ -1255,29 +1370,32 @@ class Session:
                 self._caches.update({name: c})
             return c
 
-    def is_active(self) -> bool:
+    def is_ready(self) -> bool:
         """
         Returns
         :return:
         """
-        return self._active
+        if self._closed:
+            return False
 
-    async def _set_active(self, active: bool) -> None:
-        self._active = active
-        if self._active:
-            if not self._active_condition.locked():
-                await self._active_condition.acquire()
-            self._active_condition.notify_all()
-            self._active_condition.release()
+        return True if not self._ready_enabled else self._ready
+
+    async def _set_ready(self, ready: bool) -> None:
+        self._ready = ready
+        if self._ready:
+            if not self._ready_condition.locked():
+                await self._ready_condition.acquire()
+            self._ready_condition.notify_all()
+            self._ready_condition.release()
         else:
-            await self._active_condition.acquire()
+            await self._ready_condition.acquire()
 
-    async def _wait_for_active(self) -> None:
-        if not self.is_active():
-            timeout: float = self._session_options.request_timeout_seconds
-            COH_LOG.debug("Waiting for session to become active; timeout=[%s seconds]", timeout)
+    async def _wait_for_ready(self) -> None:
+        if self._ready_enabled and not self.is_ready():
+            timeout: float = self._ready_timeout_seconds
+            COH_LOG.debug(f"Waiting for session {self.session_id} to become active; timeout=[{timeout} seconds]")
             async with asyncio.timeout(timeout):
-                await self._active_condition.wait()
+                await self._ready_condition.wait()
 
     # noinspection PyUnresolvedReferences
     async def close(self) -> None:
@@ -1297,7 +1415,8 @@ class Session:
 
             self._caches.clear()
 
-            await self._channel.close()  # TODO: consider grace period?
+            await self._channel.close() # TODO: consider grace period?
+            self._channel = None
 
     def _setup_event_handlers(self, client: NamedCacheClient[K, V]) -> None:
         this: Session = self
@@ -1340,7 +1459,7 @@ class _BaseInterceptor:
             self._session.options.request_timeout_seconds,
             client_call_details.metadata,
             client_call_details.credentials,
-            True,
+            True if self._session._ready_enabled else None,
         )
         return await continuation(new_details, request)
 
@@ -1391,37 +1510,73 @@ async def watch_channel_state(session: Session) -> None:
     emitter: EventEmitter = session._emitter
     channel: grpc.aio.Channel = session.channel
     first_connect: bool = True
+    connected: bool = False
     last_state: grpc.ChannelConnectivity = grpc.ChannelConnectivity.IDLE
+    disconnect_time: float = 0
+
+    def current_milli_time() -> float:
+        return round(time.time() * 1000)
 
     try:
         while True:
-            state: grpc.ChannelConnectivity = channel.get_state(False)
-            COH_LOG.debug("New Channel State: transitioning from [%s] to [%s]", last_state, state)
+            state: grpc.ChannelConnectivity = channel.get_state(True)
+            if COH_LOG.isEnabledFor(logging.DEBUG):
+                COH_LOG.debug(f"New Channel State: transitioning from [{last_state}] to [{state}].")
             match state:
                 case grpc.ChannelConnectivity.SHUTDOWN:
-                    COH_LOG.info("Session to [%s] terminated", session.options.address)
-                    await session._set_active(False)
+                    COH_LOG.info(f"Session [{session.session_id}] terminated.")
+                    await session._set_ready(False)
+                    await session.close()
+                    return
                 case grpc.ChannelConnectivity.READY:
-                    if not first_connect and not session.is_active():
-                        COH_LOG.info("Session re-established to [%s]", session.options.address)
-
+                    if not first_connect and not connected:
+                        connected = True
+                        disconnect_time = 0
+                        COH_LOG.info(f"Session [{session.session_id} re-connected to [{session.options.address}].")
                         await emitter.emit_async(SessionLifecycleEvent.RECONNECTED.value)
-                        await session._set_active(True)
-                    elif first_connect and not session.is_active():
-                        COH_LOG.info("Session established to [%s]", session.options.address)
+                        await session._set_ready(True)
+                    elif first_connect and not connected:
+                        connected = True
+                        COH_LOG.info(f"Session [{session.session_id}] connected to [{session.options.address}].")
 
                         first_connect = False
                         await emitter.emit_async(SessionLifecycleEvent.CONNECTED.value)
-                        await session._set_active(True)
+                        await session._set_ready(True)
                 case _:
-                    if session.is_active():
-                        COH_LOG.warning("Session to [%s] disconnected; will attempt reconnect", session.options.address)
+                    if connected:
+                        connected = False
+                        disconnect_time = -1
+                        COH_LOG.warning(
+                            f"Session [{session.session_id}] disconnected from [{session.options.address}];"
+                            f" will attempt reconnect."
+                        )
 
                         await emitter.emit_async(SessionLifecycleEvent.DISCONNECTED.value)
-                        await session._set_active(False)
+                        await session._set_ready(False)
 
-            COH_LOG.debug("Waiting for state change from [%s]", state)
-            await channel.wait_for_state_change(channel.get_state(True))
+                    if disconnect_time != 0:
+                        if disconnect_time == -1:
+                            disconnect_time = current_milli_time()
+                        else:
+                            waited: float = current_milli_time() - disconnect_time
+                            timeout = session.options.session_disconnect_timeout_seconds
+                            if COH_LOG.isEnabledFor(logging.DEBUG):
+                                COH_LOG.debug(
+                                    f"Waited [{waited / 1000} seconds] for session [{session.session_id}] to reconnect."
+                                    f" [~{(round(timeout - (waited / 1000)))} seconds] remaining to reconnect."
+                                )
+                            if waited >= timeout:
+                                COH_LOG.error(
+                                    f"session [{session.session_id}] unable to reconnect within [{timeout} seconds."
+                                    f"  Closing session."
+                                )
+                                await session.close()
+                                return
+
+            state = channel.get_state(True)
+            if COH_LOG.isEnabledFor(logging.DEBUG):
+                COH_LOG.debug(f"Waiting for state change from [{state}]")
+            await channel.wait_for_state_change(state)
     except asyncio.CancelledError:
         return
 

--- a/src/coherence/client.py
+++ b/src/coherence/client.py
@@ -1415,7 +1415,7 @@ class Session:
 
             self._caches.clear()
 
-            await self._channel.close() # TODO: consider grace period?
+            await self._channel.close()  # TODO: consider grace period?
             self._channel = None
 
     def _setup_event_handlers(self, client: NamedCacheClient[K, V]) -> None:

--- a/src/coherence/client.py
+++ b/src/coherence/client.py
@@ -935,9 +935,9 @@ class Options:
     """The default scope."""
     DEFAULT_REQUEST_TIMEOUT: Final[float] = 30.0
     """The default request timeout."""
-    DEFAULT_READY_TIMEOUT: Final[float] = -1.0
+    DEFAULT_READY_TIMEOUT: Final[float] = 0
     """
-    The default ready timeout is -1.0 which disables the feature by default.  Explicit configure the ready timeout
+    The default ready timeout is 0 which disables the feature by default.  Explicitly configure the ready timeout
     session option or use the environment variable to specify a positive value indicating how many seconds an RPC will
     wait for the underlying channel to be ready before failing.
     """
@@ -972,7 +972,7 @@ class Options:
           See also :func:`coherence.client.Options.ENV_REQUEST_TIMEOUT`
         :param ready_timeout_seconds: Defines the ready timeout, in `seconds`.  If this is a positive
           float value, remote calls will not fail immediately if no connection is available.  If this is a value of zero
-          or less, then remote calls will fail-fast.  If not explicitly configured, the default of -1 is assumed.
+          or less, then remote calls will fail-fast.  If not explicitly configured, the default of 0 is assumed.
 
           See also :class:`coherence.client.Options.ENV_READY_TIMEOUT`
         :param session_disconnect_seconds: Defines the maximum time, in `seconds`, that a session may remain in

--- a/src/coherence/serialization.py
+++ b/src/coherence/serialization.py
@@ -36,11 +36,15 @@ class Serializer(ABC):
     def deserialize(self, value: bytes) -> T:  # type: ignore
         """documentation"""
 
+    @property
     def format(self) -> str:
         return self._ser_format
 
     def __init__(self, ser_format: str):
         self._ser_format = ser_format
+
+    def __str__(self) -> str:
+        return f"Serializer(format={self.format})"
 
 
 class JSONSerializer(Serializer):

--- a/src/coherence/util.py
+++ b/src/coherence/util.py
@@ -63,7 +63,7 @@ class RequestFactory:
         p = PutRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
             value=self._serializer.serialize(value),
             ttl=ttl,
@@ -74,7 +74,7 @@ class RequestFactory:
         g = GetRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
         )
         return g
@@ -83,7 +83,7 @@ class RequestFactory:
         if keys is None:
             raise ValueError("Must specify a set of keys")
 
-        g: GetAllRequest = GetAllRequest(scope=self._scope, cache=self._cache_name, format=self._serializer.format())
+        g: GetAllRequest = GetAllRequest(scope=self._scope, cache=self._cache_name, format=self._serializer.format)
 
         for key in keys:
             g.key.append(self._serializer.serialize(key))
@@ -94,7 +94,7 @@ class RequestFactory:
         p = PutIfAbsentRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
             value=self._serializer.serialize(value),
             ttl=ttl,
@@ -108,7 +108,7 @@ class RequestFactory:
             v = self._serializer.serialize(value)
             e = Entry(key=k, value=v)
             entry_list.append(e)
-        p = PutAllRequest(scope=self._scope, cache=self._cache_name, format=self._serializer.format(), entry=entry_list)
+        p = PutAllRequest(scope=self._scope, cache=self._cache_name, format=self._serializer.format, entry=entry_list)
         return p
 
     def clear_request(self) -> ClearRequest:
@@ -127,7 +127,7 @@ class RequestFactory:
         r = RemoveRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
         )
         return r
@@ -136,7 +136,7 @@ class RequestFactory:
         r = RemoveMappingRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
             value=self._serializer.serialize(value),
         )
@@ -146,7 +146,7 @@ class RequestFactory:
         r = ReplaceRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
             value=self._serializer.serialize(value),
         )
@@ -156,7 +156,7 @@ class RequestFactory:
         r = ReplaceMappingRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
             previousValue=self._serializer.serialize(old_value),
             newValue=self._serializer.serialize(new_value),
@@ -167,7 +167,7 @@ class RequestFactory:
         r = ContainsKeyRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             key=self._serializer.serialize(key),
         )
         return r
@@ -176,7 +176,7 @@ class RequestFactory:
         r = ContainsValueRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             value=self._serializer.serialize(value),
         )
         return r
@@ -193,7 +193,7 @@ class RequestFactory:
         r = InvokeRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             processor=self._serializer.serialize(processor),
             key=self._serializer.serialize(key),
         )
@@ -208,7 +208,7 @@ class RequestFactory:
         r = InvokeAllRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             processor=self._serializer.serialize(processor),
         )
 
@@ -229,7 +229,7 @@ class RequestFactory:
         r: AggregateRequest = AggregateRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
             aggregator=self._serializer.serialize(aggregator),
         )
 
@@ -248,7 +248,7 @@ class RequestFactory:
         r: ValuesRequest = ValuesRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
         )
 
         if filter is not None:
@@ -263,7 +263,7 @@ class RequestFactory:
         r: KeySetRequest = KeySetRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
         )
 
         if filter is not None:
@@ -280,7 +280,7 @@ class RequestFactory:
         r: EntrySetRequest = EntrySetRequest(
             scope=self._scope,
             cache=self._cache_name,
-            format=self._serializer.format(),
+            format=self._serializer.format,
         )
 
         if filter is not None:
@@ -300,7 +300,7 @@ class RequestFactory:
         """
 
         r: PageRequest = PageRequest(
-            scope=self._scope, cache=self._cache_name, format=self._serializer.format(), cookie=cookie
+            scope=self._scope, cache=self._cache_name, format=self._serializer.format, cookie=cookie
         )
 
         return r
@@ -314,7 +314,7 @@ class RequestFactory:
             raise AssertionError("Must specify a key or a filter")
 
         request: MapListenerRequest = MapListenerRequest(
-            cache=self._cache_name, scope=self._scope, format=self._serializer.format()
+            cache=self._cache_name, scope=self._scope, format=self._serializer.format
         )
 
         request.lite = lite
@@ -340,7 +340,7 @@ class RequestFactory:
 
     def map_event_subscribe(self) -> MapListenerRequest:
         request: MapListenerRequest = MapListenerRequest(
-            cache=self._cache_name, scope=self._scope, format=self._serializer.format()
+            cache=self._cache_name, scope=self._scope, format=self._serializer.format
         )
         request.uid = self.__generate_next_request_id("init")
         request.subscribe = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -175,7 +175,7 @@ class CountingMapListener(MapListener[K, V]):
             await asyncio.sleep(0)
 
 
-async def get_session(wait_for_ready: float = -1.0) -> Session:
+async def get_session(wait_for_ready: float = 0) -> Session:
     default_address: Final[str] = "localhost:1408"
     default_scope: Final[str] = ""
     default_request_timeout: Final[float] = 30.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -202,7 +202,7 @@ async def get_session(wait_for_ready: float = 0) -> Session:
         options.channel_options = (("grpc.ssl_target_name_override", "Star-Lord"),)
         session = await Session.create(options)
     else:
-        session = await Session.create()
+        session = await Session.create(Options(ready_timeout_seconds=wait_for_ready))
 
     return session
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging.config
 import os
+from asyncio import Event
 from typing import Final, List, TypeVar
 
 import pytest
@@ -204,3 +205,7 @@ async def get_session(wait_for_ready: float = 0) -> Session:
         session = await Session.create()
 
     return session
+
+
+async def wait_for(event: Event, timeout: float) -> None:
+    await asyncio.wait_for(event.wait(), timeout)

--- a/tests/logging.conf
+++ b/tests/logging.conf
@@ -16,20 +16,20 @@ level=INFO
 handlers=consoleHandler
 
 [logger_coherence]
-level=INFO
+level=DEBUG
 handlers=consoleHandler
 qualname=coherence
 propagate=0
 
 [logger_coherence-test]
-level=INFO
+level=DEBUG
 handlers=consoleHandler
 qualname=coherence-test
 propagate=0
 
 [handler_consoleHandler]
 class=StreamHandler
-level=INFO
+level=DEBUG
 formatter=sampleFormatter
 args=(sys.stdout,)
 

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -2,14 +2,14 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 
-import os
 from decimal import Decimal
-from typing import Any, AsyncGenerator, Final, List, cast
+from typing import Any, AsyncGenerator, List, cast
 
 import pytest
 import pytest_asyncio
 
-from coherence import Aggregators, Filters, NamedCache, Options, Session, TlsOptions
+import tests
+from coherence import Aggregators, Filters, NamedCache, Session
 from coherence.aggregator import (
     EntryAggregator,
     PriorityAggregator,
@@ -24,38 +24,9 @@ from coherence.serialization import JSONSerializer
 from tests.person import Person
 
 
-async def get_session() -> Session:
-    default_address: Final[str] = "localhost:1408"
-    default_scope: Final[str] = ""
-    default_request_timeout: Final[float] = 30.0
-    default_format: Final[str] = "json"
-
-    run_secure: Final[str] = "RUN_SECURE"
-    session: Session
-
-    if run_secure in os.environ:
-        # Default TlsOptions constructor will pick up the SSL Certs and
-        # Key values from these environment variables:
-        # COHERENCE_TLS_CERTS_PATH
-        # COHERENCE_TLS_CLIENT_CERT
-        # COHERENCE_TLS_CLIENT_KEY
-        tls_options: TlsOptions = TlsOptions()
-        tls_options.enabled = True
-        tls_options.locked()
-
-        options: Options = Options(default_address, default_scope, default_request_timeout, default_format)
-        options.tls_options = tls_options
-        options.channel_options = (("grpc.ssl_target_name_override", "Star-Lord"),)
-        session = Session(options)
-    else:
-        session = await Session.create()
-
-    return session
-
-
 @pytest_asyncio.fixture
 async def setup_and_teardown() -> AsyncGenerator[NamedCache[Any, Any], None]:
-    session: Session = await get_session()
+    session: Session = await tests.get_session()
     cache: NamedCache[Any, Any] = await session.get_cache("test")
 
     await cache.put(Person.Pat().name, Person.Pat())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,11 +3,6 @@
 # https://oss.oracle.com/licenses/upl.
 
 import asyncio
-import logging
-import logging.config
-import os
-import urllib
-import urllib.request
 from asyncio import Event
 from time import time
 from typing import Any, AsyncGenerator, Final, Optional, TypeVar
@@ -15,19 +10,17 @@ from typing import Any, AsyncGenerator, Final, Optional, TypeVar
 import pytest
 import pytest_asyncio
 
-from coherence import Filters, MapEntry, NamedCache, Options, Session, TlsOptions
-from coherence.event import MapLifecycleEvent, SessionLifecycleEvent
+import tests
+from coherence import Filters, MapEntry, NamedCache, Session
+from coherence.event import MapLifecycleEvent
 from coherence.extractor import ChainedExtractor, UniversalExtractor
 from coherence.processor import ExtractorProcessor
-from tests import CountingMapListener
 from tests.address import Address
 from tests.person import Person
 
 K = TypeVar("K")
 V = TypeVar("V")
 R = TypeVar("R")
-
-COH_LOG = logging.getLogger("coherence-test")
 
 
 async def _insert_large_number_of_entries(cache: NamedCache[str, str]) -> int:
@@ -48,38 +41,9 @@ async def _insert_large_number_of_entries(cache: NamedCache[str, str]) -> int:
     return num_entries
 
 
-async def get_session() -> Session:
-    default_address: Final[str] = "localhost:1408"
-    default_scope: Final[str] = ""
-    default_request_timeout: Final[float] = 30.0
-    default_format: Final[str] = "json"
-
-    run_secure: Final[str] = "RUN_SECURE"
-    session: Session
-
-    if run_secure in os.environ:
-        # Default TlsOptions constructor will pick up the SSL Certs and
-        # Key values from these environment variables:
-        # COHERENCE_TLS_CERTS_PATH
-        # COHERENCE_TLS_CLIENT_CERT
-        # COHERENCE_TLS_CLIENT_KEY
-        tls_options: TlsOptions = TlsOptions()
-        tls_options.enabled = True
-        tls_options.locked()
-
-        options: Options = Options(default_address, default_scope, default_request_timeout, default_format)
-        options.tls_options = tls_options
-        options.channel_options = (("grpc.ssl_target_name_override", "Star-Lord"),)
-        session = await Session.create(options)
-    else:
-        session = await Session.create()
-
-    return session
-
-
 @pytest_asyncio.fixture
 async def setup_and_teardown() -> AsyncGenerator[NamedCache[Any, Any], None]:
-    session: Session = await get_session()
+    session: Session = await tests.get_session()
 
     cache: NamedCache[Any, Any] = await session.get_cache("test")
 
@@ -92,7 +56,7 @@ async def setup_and_teardown() -> AsyncGenerator[NamedCache[Any, Any], None]:
 
 @pytest_asyncio.fixture
 async def setup_and_teardown_person_cache() -> AsyncGenerator[NamedCache[str, Person], None]:
-    session: Session = await get_session()
+    session: Session = await tests.get_session()
 
     cache: NamedCache[str, Person] = await session.get_cache("test")
 
@@ -116,43 +80,6 @@ async def setup_and_teardown_person_cache() -> AsyncGenerator[NamedCache[str, Pe
     await cache.truncate()
     await cache.destroy()
     await session.close()
-
-
-@pytest.mark.asyncio
-async def test_session_basics() -> None:
-    """Test initial session state; CLOSED lifecycle event; and post-close invocations raise error"""
-
-    session: Session = await get_session()
-
-    assert session.channel is not None
-    assert session.scope == ""
-    assert session.options is not None
-    assert session.format == "json"
-    assert not session.closed
-
-    event: Event = Event()
-    session.on(SessionLifecycleEvent.CLOSED, lambda: event.set())
-    await session.close()
-    await asyncio.wait_for(_waiter(event), 0.5)
-
-    # ensure close is idempotent
-    event.clear()
-    await session.close()
-
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(_waiter(event), 0.5)
-
-    assert session.channel is not None
-    assert session.scope == ""
-    assert session.options is not None
-    assert session.format == "json"
-    assert session.closed
-
-    with pytest.raises(Exception):
-        await session.get_cache("test")
-
-    with pytest.raises(Exception):
-        session.on(SessionLifecycleEvent.CLOSED, lambda: None)
 
 
 # noinspection PyShadowingNames
@@ -387,7 +314,7 @@ async def test_get_all_no_keys_raises_error(setup_and_teardown: NamedCache[str, 
 
     with pytest.raises(ValueError):
         # noinspection PyTypeChecker
-        await cache.get_all(None)  # type: ignore
+        await cache.get_all(None)
 
 
 # noinspection PyShadowingNames
@@ -610,7 +537,7 @@ async def test_cache_truncate_event(setup_and_teardown: NamedCache[str, str]) ->
 # noinspection PyShadowingNames,DuplicatedCode
 @pytest.mark.asyncio
 async def test_cache_release_event() -> None:
-    session: Session = await get_session()
+    session: Session = await tests.get_session()
     cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
     name: str = "UNSET"
     event: Event = Event()
@@ -633,158 +560,6 @@ async def test_cache_release_event() -> None:
         assert name == cache.name
         assert cache.released
         assert not cache.destroyed
-        assert not cache.active
-    finally:
-        await session.close()
-
-
-# noinspection PyShadowingNames
-@pytest.mark.asyncio
-async def test_cache_destroy_event() -> None:
-    session: Session = await get_session()
-    cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
-    name: str = "UNSET"
-    event: Event = Event()
-
-    def callback(n: str) -> None:
-        nonlocal name
-        name = n
-        event.set()
-
-    cache.on(MapLifecycleEvent.DESTROYED, callback)
-
-    try:
-        await cache.put("A", "B")
-        await cache.put("C", "D")
-        assert await cache.size() == 2
-
-        await cache.destroy()
-        await asyncio.wait_for(_waiter(event), EVENT_TIMEOUT)
-
-        assert name == cache.name
-        assert not cache.released
-        assert cache.destroyed
-        assert not cache.active
-    finally:
-        await session.close()
-
-
-# noinspection PyShadowingNames,DuplicatedCode
-@pytest.mark.asyncio
-async def test_session_release_event() -> None:
-    session: Session = await get_session()
-    cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
-    name: str = "UNSET"
-    event: Event = Event()
-
-    def callback(n: str) -> None:
-        nonlocal name
-        name = n
-        event.set()
-
-    session.on(MapLifecycleEvent.RELEASED, callback)
-
-    try:
-        await cache.put("A", "B")
-        await cache.put("C", "D")
-        assert await cache.size() == 2
-
-        cache.release()
-        await asyncio.wait_for(_waiter(event), EVENT_TIMEOUT)
-
-        assert name == cache.name
-        assert cache.released
-        assert not cache.destroyed
-        assert not cache.active
-    finally:
-        await session.close()
-
-
-@pytest.mark.asyncio
-async def test_session_reconnect() -> None:
-    session: Session = await get_session()
-    logging.debug("Getting cache ...")
-
-    try:
-        count: int = 50
-        cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
-
-        listener: CountingMapListener[str, str] = CountingMapListener("Test")
-
-        COH_LOG.debug("Adding MapListener ...")
-        await cache.add_map_listener(listener)
-
-        COH_LOG.debug("Inserting values ...")
-        for i in range(count):
-            await cache.put(str(i), str(i))
-
-        COH_LOG.debug("Waiting for [%s] MapEvents ...", count)
-        await listener.wait_for(count, 15)
-        COH_LOG.debug("All events received!")
-
-        listener.reset()
-
-        disc_event: Event = Event()
-
-        def disc() -> None:
-            COH_LOG.debug("Detected session disconnect!")
-            nonlocal disc_event
-            disc_event.set()
-
-        session.on(SessionLifecycleEvent.DISCONNECTED, disc)
-
-        COH_LOG.debug("Shutting down the gRPC Proxy ...")
-        req: urllib.request.Request = urllib.request.Request(
-            "http://127.0.0.1:30000/management/coherence/cluster/services/$GRPC:GrpcProxy/members/1/stop", method="POST"
-        )
-        with urllib.request.urlopen(req) as response:
-            response.read()
-
-        COH_LOG.debug("Waiting for session disconnect ...")
-        async with asyncio.timeout(10):
-            await disc_event.wait()
-
-        # start inserting values as soon as disconnect occurs to ensure
-        # that we properly wait for the session to reconnect before
-        # issuing RPC
-        COH_LOG.debug("Inserting second set of values ...")
-        for i in range(count):
-            await cache.put(str(i), str(i))
-
-        COH_LOG.debug("Waiting for [%s] MapEvents ...", count)
-        await listener.wait_for(count, 15)
-        COH_LOG.debug("All events received!")
-
-    finally:
-        await session.close()
-
-
-# noinspection PyShadowingNames
-@pytest.mark.asyncio
-async def test_session_destroy_event() -> None:
-    session: Session = await get_session()
-    cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
-    name: str = "UNSET"
-    event: Event = Event()
-
-    def callback(n: str) -> None:
-        nonlocal name
-        name = n
-        event.set()
-
-    session.on(MapLifecycleEvent.DESTROYED, callback)
-
-    try:
-        await cache.put("A", "B")
-        await cache.put("C", "D")
-        assert await cache.size() == 2
-
-        await cache.destroy()
-        await asyncio.wait_for(_waiter(event), EVENT_TIMEOUT)
-
-        assert name == cache.name
-        assert not cache.released
-        assert cache.destroyed
         assert not cache.active
     finally:
         await session.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 
-import asyncio
 from asyncio import Event
 from time import time
 from typing import Any, AsyncGenerator, Final, Optional, TypeVar
@@ -528,7 +527,7 @@ async def test_cache_truncate_event(setup_and_teardown: NamedCache[str, str]) ->
     assert await cache.size() == 2
 
     await cache.truncate()
-    await asyncio.wait_for(_waiter(event), EVENT_TIMEOUT)
+    await tests.wait_for(event, EVENT_TIMEOUT)
 
     assert name == cache.name
     assert await cache.size() == 0
@@ -555,7 +554,7 @@ async def test_cache_release_event() -> None:
         assert await cache.size() == 2
 
         cache.release()
-        await asyncio.wait_for(_waiter(event), EVENT_TIMEOUT)
+        await tests.wait_for(event, EVENT_TIMEOUT)
 
         assert name == cache.name
         assert cache.released
@@ -563,7 +562,3 @@ async def test_cache_release_event() -> None:
         assert not cache.active
     finally:
         await session.close()
-
-
-async def _waiter(event: Event) -> None:
-    await event.wait()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,49 +2,20 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 
-import os
-from typing import Any, AsyncGenerator, Final
+from typing import Any, AsyncGenerator
 
 import pytest
 import pytest_asyncio
 
-from coherence import NamedCache, Options, Session, TlsOptions
+import tests
+from coherence import NamedCache, Session
 from coherence.filter import Filters
 from coherence.processor import ConditionalRemove, EntryProcessor
 
 
-async def get_session() -> Session:
-    default_address: Final[str] = "localhost:1408"
-    default_scope: Final[str] = ""
-    default_request_timeout: Final[float] = 30.0
-    default_format: Final[str] = "json"
-
-    run_secure: Final[str] = "RUN_SECURE"
-    session: Session
-
-    if run_secure in os.environ:
-        # Default TlsOptions constructor will pick up the SSL Certs and
-        # Key values from these environment variables:
-        # COHERENCE_TLS_CERTS_PATH
-        # COHERENCE_TLS_CLIENT_CERT
-        # COHERENCE_TLS_CLIENT_KEY
-        tls_options: TlsOptions = TlsOptions()
-        tls_options.enabled = True
-        tls_options.locked()
-
-        options: Options = Options(default_address, default_scope, default_request_timeout, default_format)
-        options.tls_options = tls_options
-        options.channel_options = (("grpc.ssl_target_name_override", "Star-Lord"),)
-        session = await Session.create(options)
-    else:
-        session = await Session.create()
-
-    return session
-
-
 @pytest_asyncio.fixture
 async def setup_and_teardown() -> AsyncGenerator[NamedCache[Any, Any], None]:
-    session: Session = await get_session()
+    session: Session = await tests.get_session()
     cache: NamedCache[Any, Any] = await session.get_cache("test")
 
     yield cache

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -2,13 +2,13 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 
-import os
-from typing import Any, AsyncGenerator, Final
+from typing import Any, AsyncGenerator
 
 import pytest
 import pytest_asyncio
 
-from coherence import MapEntry, NamedCache, Options, Session, TlsOptions
+import tests
+from coherence import MapEntry, NamedCache, Session
 from coherence.filter import Filter, Filters
 from coherence.processor import EntryProcessor, Numeric, PreloadRequest, Processors, ScriptProcessor, TouchProcessor
 from coherence.serialization import JSONSerializer
@@ -16,38 +16,9 @@ from tests.address import Address
 from tests.person import Person
 
 
-async def get_session() -> Session:
-    default_address: Final[str] = "localhost:1408"
-    default_scope: Final[str] = ""
-    default_request_timeout: Final[float] = 30.0
-    default_format: Final[str] = "json"
-
-    run_secure: Final[str] = "RUN_SECURE"
-    session: Session
-
-    if run_secure in os.environ:
-        # Default TlsOptions constructor will pick up the SSL Certs and
-        # Key values from these environment variables:
-        # COHERENCE_TLS_CERTS_PATH
-        # COHERENCE_TLS_CLIENT_CERT
-        # COHERENCE_TLS_CLIENT_KEY
-        tls_options: TlsOptions = TlsOptions()
-        tls_options.enabled = True
-        tls_options.locked()
-
-        options: Options = Options(default_address, default_scope, default_request_timeout, default_format)
-        options.tls_options = tls_options
-        options.channel_options = (("grpc.ssl_target_name_override", "Star-Lord"),)
-        session = await Session.create(options)
-    else:
-        session = await Session.create()
-
-    return session
-
-
 @pytest_asyncio.fixture
 async def setup_and_teardown() -> AsyncGenerator[NamedCache[Any, Any], None]:
-    session: Session = await get_session()
+    session: Session = await tests.get_session()
     cache: NamedCache[Any, Any] = await session.get_cache("test")
 
     yield cache

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -29,64 +29,44 @@ async def test_basics() -> None:
     run_secure: str = "RUN_SECURE"
     session: Session = await tests.get_session()
 
+    def check_basics() -> None:
+        assert session.scope == Options.DEFAULT_SCOPE
+        assert session.format == Options.DEFAULT_FORMAT
+        assert session.session_id is not None
+        assert session.options is not None
+
+        if run_secure in os.environ:
+            assert session.options.tls_options is not None
+            assert session.options.tls_options.enabled
+            assert session.options.tls_options.client_key_path == os.environ.get(TlsOptions.ENV_CLIENT_KEY)
+            assert session.options.tls_options.ca_cert_path == os.environ.get(TlsOptions.ENV_CA_CERT)
+            assert session.options.tls_options.client_cert_path == os.environ.get(TlsOptions.ENV_CLIENT_CERT)
+        else:
+            assert session.options.tls_options is None
+            assert session.options.channel_options is None
+
+        assert session.options.session_disconnect_timeout_seconds == Options.DEFAULT_SESSION_DISCONNECT_TIMEOUT
+
+        if Options.ENV_REQUEST_TIMEOUT in os.environ:
+            assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT, "-1"))
+        else:
+            assert session.options.request_timeout_seconds == Options.DEFAULT_REQUEST_TIMEOUT
+
+        assert session.options.ready_timeout_seconds == Options.DEFAULT_READY_TIMEOUT
+        assert session.options.format == Options.DEFAULT_FORMAT
+        assert session.options.scope == Options.DEFAULT_SCOPE
+        assert session.options.address == Options.DEFAULT_ADDRESS
+
+    check_basics()
     assert session.channel is not None
-    assert session.scope == Options.DEFAULT_SCOPE
-    assert session.format == Options.DEFAULT_FORMAT
-    assert session.session_id is not None
-    assert session.options is not None
-
-    if run_secure in os.environ:
-        assert session.options.tls_options is not None
-        assert session.options.tls_options.enabled
-        assert session.options.tls_options.client_key_path == os.environ.get(TlsOptions.ENV_CLIENT_KEY)
-        assert session.options.tls_options.ca_cert_path == os.environ.get(TlsOptions.ENV_CA_CERT)
-        assert session.options.tls_options.client_cert_path == os.environ.get(TlsOptions.ENV_CLIENT_CERT)
-    else:
-        assert session.options.tls_options is None
-        assert session.options.channel_options is None
-
-    assert session.options.session_disconnect_timeout_seconds == Options.DEFAULT_SESSION_DISCONNECT_TIMEOUT
-
-    if Options.ENV_REQUEST_TIMEOUT in os.environ:
-        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT, "-1"))
-    else:
-        assert session.options.request_timeout_seconds == Options.DEFAULT_REQUEST_TIMEOUT
-
-    assert session.options.ready_timeout_seconds == Options.DEFAULT_READY_TIMEOUT
-    assert session.options.format == Options.DEFAULT_FORMAT
-    assert session.options.scope == Options.DEFAULT_SCOPE
-    assert session.options.address == Options.DEFAULT_ADDRESS
     assert session.is_ready()
     assert not session.closed
 
     await session.close()
     await asyncio.sleep(0.1)
 
+    check_basics()
     assert session.channel is None
-    assert session.scope == ""
-    assert session.options is not None
-
-    if run_secure in os.environ:
-        assert session.options.tls_options is not None
-        assert session.options.tls_options.enabled
-        assert session.options.tls_options.client_key_path == os.environ.get(TlsOptions.ENV_CLIENT_KEY)
-        assert session.options.tls_options.ca_cert_path == os.environ.get(TlsOptions.ENV_CA_CERT)
-        assert session.options.tls_options.client_cert_path == os.environ.get(TlsOptions.ENV_CLIENT_CERT)
-    else:
-        assert session.options.tls_options is None
-        assert session.options.channel_options is None
-
-    assert session.options.session_disconnect_timeout_seconds == Options.DEFAULT_SESSION_DISCONNECT_TIMEOUT
-
-    if Options.ENV_REQUEST_TIMEOUT in os.environ:
-        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT, "-1"))
-    else:
-        assert session.options.request_timeout_seconds == Options.DEFAULT_REQUEST_TIMEOUT
-
-    assert session.options.ready_timeout_seconds == Options.DEFAULT_READY_TIMEOUT
-    assert session.options.format == Options.DEFAULT_FORMAT
-    assert session.options.scope == Options.DEFAULT_SCOPE
-    assert session.options.address == Options.DEFAULT_ADDRESS
     assert not session.is_ready()
     assert session.closed
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -14,7 +14,7 @@ from typing import Final
 import pytest
 
 import tests
-from coherence import NamedCache, Session, Options, TlsOptions
+from coherence import NamedCache, Options, Session, TlsOptions
 from coherence.event import MapLifecycleEvent, SessionLifecycleEvent
 from tests import CountingMapListener
 
@@ -48,7 +48,7 @@ async def test_basics() -> None:
     assert session.options.session_disconnect_timeout_seconds == Options.DEFAULT_SESSION_DISCONNECT_TIMEOUT
 
     if Options.ENV_REQUEST_TIMEOUT in os.environ:
-        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT))
+        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT, "-1"))
     else:
         assert session.options.request_timeout_seconds == Options.DEFAULT_REQUEST_TIMEOUT
 
@@ -60,7 +60,7 @@ async def test_basics() -> None:
     assert not session.closed
 
     await session.close()
-    await asyncio.sleep(.1)
+    await asyncio.sleep(0.1)
 
     assert session.channel is None
     assert session.scope == ""
@@ -79,7 +79,7 @@ async def test_basics() -> None:
     assert session.options.session_disconnect_timeout_seconds == Options.DEFAULT_SESSION_DISCONNECT_TIMEOUT
 
     if Options.ENV_REQUEST_TIMEOUT in os.environ:
-        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT))
+        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT, "-1"))
     else:
         assert session.options.request_timeout_seconds == Options.DEFAULT_REQUEST_TIMEOUT
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -147,8 +147,6 @@ async def test_wait_for_ready() -> None:
     try:
         count: int = 50
         cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
-        print(f"Cache -> {cache}")
-        return
 
         listener: CountingMapListener[str, str] = CountingMapListener("Test")
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,7 +19,7 @@ from coherence.event import MapLifecycleEvent, SessionLifecycleEvent
 from tests import CountingMapListener
 
 COH_LOG = logging.getLogger("coherence-test")
-EVENT_TIMEOUT: Final[float] = 5.0
+EVENT_TIMEOUT: Final[float] = 10.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+import asyncio
+import logging
+import os
+import urllib
+import urllib.request
+from asyncio import Event
+from time import time
+from typing import Final
+
+import pytest
+
+import tests
+from coherence import NamedCache, Session, Options, TlsOptions
+from coherence.event import MapLifecycleEvent, SessionLifecycleEvent
+from tests import CountingMapListener
+
+COH_LOG = logging.getLogger("coherence-test")
+EVENT_TIMEOUT: Final[float] = 5.0
+
+
+@pytest.mark.asyncio
+async def test_basics() -> None:
+    """Test initial session state and post-close invocations raise error"""
+
+    run_secure: str = "RUN_SECURE"
+    session: Session = await tests.get_session()
+
+    assert session.channel is not None
+    assert session.scope == Options.DEFAULT_SCOPE
+    assert session.format == Options.DEFAULT_FORMAT
+    assert session.session_id is not None
+    assert session.options is not None
+
+    if run_secure in os.environ:
+        assert session.options.tls_options is not None
+        assert session.options.tls_options.enabled
+        assert session.options.tls_options.client_key_path == os.environ.get(TlsOptions.ENV_CLIENT_KEY)
+        assert session.options.tls_options.ca_cert_path == os.environ.get(TlsOptions.ENV_CA_CERT)
+        assert session.options.tls_options.client_cert_path == os.environ.get(TlsOptions.ENV_CLIENT_CERT)
+    else:
+        assert session.options.tls_options is None
+        assert session.options.channel_options is None
+
+    assert session.options.session_disconnect_timeout_seconds == Options.DEFAULT_SESSION_DISCONNECT_TIMEOUT
+
+    if Options.ENV_REQUEST_TIMEOUT in os.environ:
+        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT))
+    else:
+        assert session.options.request_timeout_seconds == Options.DEFAULT_REQUEST_TIMEOUT
+
+    assert session.options.ready_timeout_seconds == Options.DEFAULT_READY_TIMEOUT
+    assert session.options.format == Options.DEFAULT_FORMAT
+    assert session.options.scope == Options.DEFAULT_SCOPE
+    assert session.options.address == Options.DEFAULT_ADDRESS
+    assert session.is_ready()
+    assert not session.closed
+
+    await session.close()
+    await asyncio.sleep(.1)
+
+    assert session.channel is None
+    assert session.scope == ""
+    assert session.options is not None
+
+    if run_secure in os.environ:
+        assert session.options.tls_options is not None
+        assert session.options.tls_options.enabled
+        assert session.options.tls_options.client_key_path == os.environ.get(TlsOptions.ENV_CLIENT_KEY)
+        assert session.options.tls_options.ca_cert_path == os.environ.get(TlsOptions.ENV_CA_CERT)
+        assert session.options.tls_options.client_cert_path == os.environ.get(TlsOptions.ENV_CLIENT_CERT)
+    else:
+        assert session.options.tls_options is None
+        assert session.options.channel_options is None
+
+    assert session.options.session_disconnect_timeout_seconds == Options.DEFAULT_SESSION_DISCONNECT_TIMEOUT
+
+    if Options.ENV_REQUEST_TIMEOUT in os.environ:
+        assert session.options.request_timeout_seconds == float(os.environ.get(Options.ENV_REQUEST_TIMEOUT))
+    else:
+        assert session.options.request_timeout_seconds == Options.DEFAULT_REQUEST_TIMEOUT
+
+    assert session.options.ready_timeout_seconds == Options.DEFAULT_READY_TIMEOUT
+    assert session.options.format == Options.DEFAULT_FORMAT
+    assert session.options.scope == Options.DEFAULT_SCOPE
+    assert session.options.address == Options.DEFAULT_ADDRESS
+    assert not session.is_ready()
+    assert session.closed
+
+    with pytest.raises(Exception):
+        await session.get_cache("test")
+
+    with pytest.raises(Exception):
+        session.on(SessionLifecycleEvent.CLOSED, lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_cache_release_event() -> None:
+    await _validate_cache_event(MapLifecycleEvent.RELEASED)
+
+
+@pytest.mark.asyncio
+async def test_cache_destroy_event() -> None:
+    await _validate_cache_event(MapLifecycleEvent.DESTROYED)
+
+
+@pytest.mark.asyncio
+async def test_session_lifecycle() -> None:
+    conn_event: Event = Event()
+    disconn_event: Event = Event()
+    reconn_event: Event = Event()
+    close_event: Event = Event()
+
+    def conn_callback() -> None:
+        COH_LOG.info("Connection active")
+        nonlocal conn_event
+        conn_event.set()
+
+    def disconn_callback() -> None:
+        COH_LOG.info("Detected disconnect")
+        nonlocal disconn_event
+        disconn_event.set()
+
+    def reconn_callback() -> None:
+        COH_LOG.info("Detected reconnect")
+        nonlocal reconn_event
+        reconn_event.set()
+
+    def close_callback() -> None:
+        COH_LOG.info("Detected close")
+        nonlocal close_event
+        close_event.set()
+
+    session: Session = await tests.get_session()
+    session.on(SessionLifecycleEvent.CONNECTED, conn_callback)
+    session.on(SessionLifecycleEvent.DISCONNECTED, disconn_callback)
+    session.on(SessionLifecycleEvent.RECONNECTED, reconn_callback)
+    session.on(SessionLifecycleEvent.CLOSED, close_callback)
+
+    await asyncio.wait_for(_waiter(conn_event), EVENT_TIMEOUT)
+    assert session.is_ready()
+
+    await _shutdown_proxy()
+
+    await asyncio.wait_for(_waiter(disconn_event), EVENT_TIMEOUT)
+    assert session.is_ready()
+    await asyncio.wait_for(_waiter(reconn_event), EVENT_TIMEOUT)
+    assert session.is_ready()
+
+    await session.close()
+    assert not session.is_ready()
+
+    await asyncio.wait_for(_waiter(close_event), EVENT_TIMEOUT)
+    assert not session.is_ready()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ready() -> None:
+    session: Session = await tests.get_session(10.0)
+    print(f"Session -> {session}")
+
+    logging.debug("Getting cache ...")
+
+    try:
+        count: int = 50
+        cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
+        print(f"Cache -> {cache}")
+        return
+
+        listener: CountingMapListener[str, str] = CountingMapListener("Test")
+
+        COH_LOG.debug("Adding MapListener ...")
+        await cache.add_map_listener(listener)
+
+        COH_LOG.debug("Inserting values ...")
+        for i in range(count):
+            await cache.put(str(i), str(i))
+
+        COH_LOG.debug("Waiting for [%s] MapEvents ...", count)
+        await listener.wait_for(count, 15)
+        COH_LOG.debug("All events received!")
+
+        listener.reset()
+
+        disc_event: Event = Event()
+
+        def disc() -> None:
+            COH_LOG.debug("Detected session disconnect!")
+            nonlocal disc_event
+            disc_event.set()
+
+        session.on(SessionLifecycleEvent.DISCONNECTED, disc)
+
+        await _shutdown_proxy()
+
+        COH_LOG.debug("Waiting for session disconnect ...")
+        async with asyncio.timeout(10):
+            await disc_event.wait()
+
+        # start inserting values as soon as disconnect occurs to ensure
+        # that we properly wait for the session to reconnect before
+        # issuing RPC
+        COH_LOG.debug("Inserting second set of values ...")
+        for i in range(count):
+            await cache.put(str(i), str(i))
+
+        COH_LOG.debug("Waiting for [%s] MapEvents ...", count)
+        await listener.wait_for(count, 15)
+        COH_LOG.debug("All events received!")
+
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_fail_fast() -> None:
+    session: Session = await tests.get_session()
+    logging.debug("Getting cache ...")
+
+    try:
+        count: int = 10
+        cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
+
+        listener: CountingMapListener[str, str] = CountingMapListener("Test")
+
+        COH_LOG.debug("Adding MapListener ...")
+        await cache.add_map_listener(listener)
+
+        COH_LOG.debug("Inserting values ...")
+        for i in range(count):
+            await cache.put(str(i), str(i))
+
+        COH_LOG.debug("Waiting for [%s] MapEvents ...", count)
+        await listener.wait_for(count, 15)
+        COH_LOG.debug("All events received!")
+
+        listener.reset()
+
+        disc_event: Event = Event()
+        reconn_event: Event = Event()
+
+        def disc() -> None:
+            COH_LOG.debug("Detected session disconnect!")
+            nonlocal disc_event
+            disc_event.set()
+
+        def reconn() -> None:
+            COH_LOG.debug("Detected session reconnect!")
+            nonlocal reconn_event
+            reconn_event.set()
+
+        session.on(SessionLifecycleEvent.DISCONNECTED, disc)
+        session.on(SessionLifecycleEvent.RECONNECTED, reconn)
+
+        COH_LOG.debug("Shutting down the gRPC Proxy ...")
+        req: urllib.request.Request = urllib.request.Request(
+            "http://127.0.0.1:30000/management/coherence/cluster/services/$GRPC:GrpcProxy/members/1/stop", method="POST"
+        )
+        with urllib.request.urlopen(req) as response:
+            response.read()
+
+        COH_LOG.debug("Waiting for session disconnect ...")
+        async with asyncio.timeout(10):
+            await disc_event.wait()
+
+        # start inserting values as soon as disconnect occurs to ensure
+        # that we properly wait for the session to reconnect before
+        # issuing RPC
+        COH_LOG.debug("Inserting second set of values; expecting error")
+        for i in range(count):
+            try:
+                await cache.put(str(i), str(i))
+                pytest.fail("No exception thrown by RPC")
+            except Exception as e:
+                print("Caught error: " + str(e))
+
+        COH_LOG.debug("Waiting for session reconnect ...")
+        async with asyncio.timeout(10):
+            await reconn_event.wait()
+
+    finally:
+        await session.close()
+
+
+async def _validate_cache_event(lifecycle_event: MapLifecycleEvent) -> None:
+    session: Session = await tests.get_session()
+    cache: NamedCache[str, str] = await session.get_cache("test-" + str(int(time() * 1000)))
+    name: str = "UNSET"
+    event: Event = Event()
+
+    def callback(n: str) -> None:
+        nonlocal name
+        name = n
+        event.set()
+
+    session.on(lifecycle_event, callback)
+
+    try:
+        await cache.put("A", "B")
+        await cache.put("C", "D")
+        assert await cache.size() == 2
+
+        if lifecycle_event == MapLifecycleEvent.RELEASED:
+            cache.release()
+        else:
+            await cache.destroy()
+
+        await asyncio.wait_for(_waiter(event), EVENT_TIMEOUT)
+
+        assert name == cache.name
+        assert cache.released
+
+        if lifecycle_event == MapLifecycleEvent.DESTROYED:
+            assert cache.destroyed
+        else:
+            assert not cache.destroyed
+
+        assert not cache.active
+    finally:
+        await session.close()
+
+
+async def _waiter(event: Event) -> None:
+    await event.wait()
+
+
+async def _shutdown_proxy() -> None:
+    COH_LOG.debug("Shutting down the gRPC Proxy ...")
+    req: urllib.request.Request = urllib.request.Request(
+        "http://127.0.0.1:30000/management/coherence/cluster/services/$GRPC:GrpcProxy/members/1/stop", method="POST"
+    )
+    with urllib.request.urlopen(req) as response:
+        response.read()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -120,20 +120,20 @@ async def test_session_lifecycle() -> None:
     session.on(SessionLifecycleEvent.RECONNECTED, reconn_callback)
     session.on(SessionLifecycleEvent.CLOSED, close_callback)
 
-    await asyncio.wait_for(_waiter(conn_event), EVENT_TIMEOUT)
+    await tests.wait_for(conn_event, EVENT_TIMEOUT)
     assert session.is_ready()
 
     await _shutdown_proxy()
 
-    await asyncio.wait_for(_waiter(disconn_event), EVENT_TIMEOUT)
+    await tests.wait_for(disconn_event, EVENT_TIMEOUT)
     assert session.is_ready()
-    await asyncio.wait_for(_waiter(reconn_event), EVENT_TIMEOUT)
+    await tests.wait_for(reconn_event, EVENT_TIMEOUT)
     assert session.is_ready()
 
     await session.close()
     assert not session.is_ready()
 
-    await asyncio.wait_for(_waiter(close_event), EVENT_TIMEOUT)
+    await tests.wait_for(close_event, EVENT_TIMEOUT)
     assert not session.is_ready()
 
 
@@ -288,7 +288,7 @@ async def _validate_cache_event(lifecycle_event: MapLifecycleEvent) -> None:
         else:
             await cache.destroy()
 
-        await asyncio.wait_for(_waiter(event), EVENT_TIMEOUT)
+        await tests.wait_for(event, EVENT_TIMEOUT)
 
         assert name == cache.name
         assert cache.released
@@ -301,10 +301,6 @@ async def _validate_cache_event(lifecycle_event: MapLifecycleEvent) -> None:
         assert not cache.active
     finally:
         await session.close()
-
-
-async def _waiter(event: Event) -> None:
-    await event.wait()
 
 
 async def _shutdown_proxy() -> None:


### PR DESCRIPTION
Add support to make 'WaitForReady' optional.
  * Added session configuration to control ready timeout.  If -1, the default, behavior for RPCs to fail-fast if connection isn't ready.
  * Added session configuration option to give a max time a session may be in a disconnected state.
  * refactored Session related tests into their own file.
  * Updated Makefile to execute tests in a logical order where more fundamental tests
    are run earlier.