### PR TITLE
Revert "Stop test containers after the test execution"

### DIFF
--- a/tests/scripts/run-tests.sh
+++ b/tests/scripts/run-tests.sh
@@ -23,4 +23,4 @@ RUN_SECURE=true COHERENCE_IGNORE_INVALID_CERTS=true \
   COHERENCE_TLS_CLIENT_KEY=$(pwd)/tests/utils/certs/star-lord.pem \
   COHERENCE_CLIENT_REQUEST_TIMEOUT=180.0 \
   PROFILES=,secure make clean certs test-cluster-shutdown remove-app-images \
-                                build-test-images test-cluster-startup just-wait test test-cluster-shutdown
+                                                  build-test-images test-cluster-startup just-wait test


### PR DESCRIPTION
Reverts oracle/coherence-py-client#56