### PR TITLE
Revert pytest version to 8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ jsonpickle = "~3.0"
 pymitter = ">=0.4,<0.6"
 
 [tool.poetry.dev-dependencies]
-pytest = "~8.1"
+pytest = "~8.0"
 pytest-asyncio = "~0.23"
 pytest-cov = "~4.1"
 pytest-unordered = "~0.5"


### PR DESCRIPTION
Revert pytest version to 8.0 since version 8.1 has been yanked